### PR TITLE
Addition of live release tag fetching on website navbar

### DIFF
--- a/download.html
+++ b/download.html
@@ -27,6 +27,14 @@
         <li><a href="download.html" class="active">Download</a></li>
         <!-- <li><a href="about.html">About</a></li> -->
       </ul>
+      <ul class="inline right">
+        <!--         <li><a href="login.html">Log In</a></li>
+        <li><a href="signup.html" class="button button-secondary button-m full-width-tablet" role="button">Sign Up</a> -->
+        <li><a href="https://github.com/Abir-Tx/StudyFolderOrganizer-GUI">
+            <code id="latest_github_version">Latest Version</code></a>
+        </li>
+        </li>
+      </ul>
     </nav>
   </header>
   <main>
@@ -105,6 +113,8 @@
     </section>
 
     <script src="js/main.js"></script>
+    <!-- Abir's Custom JS -->
+    <script src="js/fetch.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -64,11 +64,14 @@
         <li><a href="download.html">Download</a></li>
         <!-- <li><a href="about.html">About</a></li> -->
       </ul>
-      <!-- <ul class="inline right">
-        <li><a href="login.html">Log In</a></li>
-        <li><a href="signup.html" class="button button-secondary button-m full-width-tablet" role="button">Sign Up</a>
+      <ul class="inline right">
+        <!--         <li><a href="login.html">Log In</a></li>
+        <li><a href="signup.html" class="button button-secondary button-m full-width-tablet" role="button">Sign Up</a> -->
+        <li>
+          <code id="latest_github_version">Latest Version</code>
         </li>
-      </ul> -->
+        </li>
+      </ul>
     </nav>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@
       <ul class="inline right">
         <!--         <li><a href="login.html">Log In</a></li>
         <li><a href="signup.html" class="button button-secondary button-m full-width-tablet" role="button">Sign Up</a> -->
-        <li>
-          <code id="latest_github_version">Latest Version</code>
+        <li><a href="https://github.com/Abir-Tx/StudyFolderOrganizer-GUI">
+            <code id="latest_github_version">Latest Version</code></a>
         </li>
         </li>
       </ul>
@@ -221,6 +221,8 @@
 
   <!-- Scripts -->
   <script src="js/main.js"></script>
+  <!-- Abir's Custom JS -->
+  <script src="js/fetch.js"></script>
 
 </body>
 

--- a/js/fetch.js
+++ b/js/fetch.js
@@ -1,0 +1,11 @@
+/* JS file used to fetch github details to the website mainly to fetch the latest release tag using GitHub API */
+
+// get the elem in which the latest tag will be loaded
+var latest_github_release = document.getElementById('latest_github_version');
+console.log(latest_github_release.innerHTML);
+
+fetch('https://api.github.com/repos/Abir-Tx/StudyFolderOrganizer-GUI/releases')
+	.then(res => res.json())
+	.then(data => {
+		latest_github_release.innerHTML = 'Latest Version: ' + data[0]['tag_name'];
+	})


### PR DESCRIPTION
Show the latest release tag number from the github release in realtime on the websites navigation bar
